### PR TITLE
added scroll behavior and set for layer 0 and 2

### DIFF
--- a/config/ZaruBall.keymap
+++ b/config/ZaruBall.keymap
@@ -14,6 +14,9 @@
 #define MOUSE 4
 #define SCROLL 1
 
+// スクロール量の設定
+#define ZMK_POINTING_DEFAULT_SCRL_VAL 100
+
 / {
     conditional_layers {
         compatible = "zmk,conditional-layers";
@@ -27,6 +30,14 @@
 
 / {
     behaviors {
+        // スクロール用のbehaviorの設定
+        scroll_up_down: behavior_sensor_rotate_mouse_wheel_up_down {
+            compatible = "zmk,behavior-sensor-rotate";
+            #sensor-binding-cells = <0>;
+            bindings = <&msc SCRL_UP>, <&msc SCRL_DOWN>;
+            tap-ms = <20>; // スクロールのタップ時間
+        };
+
         td0: tap_dance_0 {
             compatible = "zmk,behavior-tap-dance";
             #binding-cells = <0>;
@@ -94,7 +105,7 @@
 
         base_layer {
             display-name = "Base";
-            sensor-bindings = <&inc_dec_kp K_SCROLL_UP K_SCROLL_DOWN>;
+                sensor-bindings = <&scroll_up_down>;
             bindings = <
 &kp ESC                  &kp N1   &kp N2     &kp N3        &kp N4     &kp N5                &kp NUMBER_6  &kp N7     &kp N8  &kp N9     &kp N0   &kp BACKSPACE
 &kp TAB                  &kp Q    &kp W      &kp E         &kp R      &kp T                 &kp Y         &kp U      &kp I   &kp O      &kp P    &kp EQUAL
@@ -118,7 +129,7 @@
 
         raise_layer {
             display-name = "Raise";
-            sensor-bindings = <&inc_dec_kp K_SCROLL_UP K_SCROLL_DOWN>;
+                sensor-bindings = <&scroll_up_down>;
             bindings = <
 &trans  &none  &none  &none      &none      &none                            &none      &none     &none     &none     &none      &none
 &trans  &none  &none  &none      &none      &none                            &none      &none     &none     &none     &none      &none


### PR DESCRIPTION
スクロールの動作をbehaviorで設定することで実現しました。
参考: https://github.com/zmkfirmware/zmk/issues/72

右クリックと{を-と入れ替えるキーマップ変更はこちらでは何もせずとも動作しました。
もう一度FWを書き込んで見たら治るかもしれません。